### PR TITLE
Fix autotest arg handling

### DIFF
--- a/substratum/autotest/autotest.go
+++ b/substratum/autotest/autotest.go
@@ -30,7 +30,7 @@ type State struct {
 func NewState(logger *log.Logger, gdbConn *substratum.GdbConnection, serialOptions serial.OpenOptions) (*State, error) {
 	serialConn, err := serial.Open(serialOptions)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open serial connection to '%s': %w", serialOptions.PortName, err)
 	}
 
 	return &State{


### PR DESCRIPTION
This allows autotest to be run successfully as-is. Also improves errors when things go wrong running autotest using go1.13 errors and `%w`